### PR TITLE
add python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
 
 # command to install dependencies
 install: pip install -r requirements.txt

--- a/congressionalrecord/cli.py
+++ b/congressionalrecord/cli.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import sys
-from pg_run.pg_cr_bulkwrite import crToPG as cr
-from fdsys.downloader import Downloader as dl
+from .pg_run.pg_cr_bulkwrite import crToPG as cr
+from .fdsys.downloader import Downloader as dl
 import argparse
 import logging
 
@@ -66,7 +68,7 @@ def main():
     elif args.do_mode == 'es':
         dl(args.start,end=args.end,do_mode='es',es_url=args.es_url,index=args.index)
     else:
-        print "Haven't written the hooks for other functionality yet."
+        print("Haven't written the hooks for other functionality yet.")
 
     logging.info('Logging ends')
 

--- a/congressionalrecord/fdsys/cr_parser.py
+++ b/congressionalrecord/fdsys/cr_parser.py
@@ -1,10 +1,12 @@
+from __future__ import absolute_import
+from builtins import object
 from bs4 import BeautifulSoup
 from io import StringIO, BytesIO
 import os
 from datetime import datetime
 import re
 import xml.etree.cElementTree as ET
-from subclasses import crItem
+from .subclasses import crItem
 import logging
 import itertools
 
@@ -105,7 +107,7 @@ class ParseCRFile(object):
         return id_num
         
     def make_re_newspeaker(self):
-        speaker_list = '|'.join([mbr for mbr in self.speakers.keys() \
+        speaker_list = '|'.join([mbr for mbr in list(self.speakers.keys()) \
         if self.speakers[mbr]['role'] == 'SPEAKING'])
         if len(speaker_list) > 0:
             re_speakers = r'^(\s{1,2}|<bullet>)(?P<name>((' + speaker_list + ')|(((Mr)|(Ms)|(Mrs)|(Miss))\. (([-A-Z\'])(\s)?)+( of [A-Z][a-z]+)?)|(((The ((VICE|ACTING|Acting) )?(PRESIDENT|SPEAKER|CHAIR(MAN)?)( pro tempore)?)|(The PRESIDING OFFICER)|(The CLERK)|(The CHIEF JUSTICE)|(The VICE PRESIDENT)|(Mr\. Counsel [A-Z]+))( \([A-Za-z.\- ]+\))?)))\.'
@@ -158,7 +160,7 @@ class ParseCRFile(object):
             self.crdoc['related_usc'] = list(
                 itertools.chain.from_iterable(
                     [[dict([('title',usc['title'])] +
-                        sec.attrs.items()) for sec
+                        list(sec.attrs.items())) for sec
                         in usc.find_all('section')]
                         for usc in related_usc]
                     )
@@ -170,7 +172,7 @@ class ParseCRFile(object):
             self.crdoc['related_statute'] = list(
                 itertools.chain.from_iterable(
                     [[dict([('volume',st['volume'])] +
-                        pg.attrs.items()) for pg
+                        list(pg.attrs.items())) for pg
                         in st.find_all('pages')]
                         for st in related_statute]
                     )
@@ -247,16 +249,16 @@ class ParseCRFile(object):
 
         This code works, though.
         """
-        header_in = self.the_text.next()
+        header_in = next(self.the_text)
         if header_in == u'':
-            header_in = self.the_text.next()
+            header_in = next(self.the_text)
         match = re.match(self.re_vol_file, header_in)
         if match:
             vol, num, wkday, month, day, year = match.group( \
             'vol','num','wkday','month','day','year')
         else:
             return False
-        header_in = self.the_text.next()
+        header_in = next(self.the_text)
         match = re.match(self.re_chamber, header_in)
         if match:
             if match.group('chamber') == 'Extensions of Remarks':
@@ -267,13 +269,13 @@ class ParseCRFile(object):
                 extensions = False
         else:
             return False
-        header_in = self.the_text.next()
+        header_in = next(self.the_text)
         match = re.match(self.re_pages, header_in)
         if match:
             pages = match.group('pages')
         else:
             return False
-        header_in = self.the_text.next()
+        header_in = next(self.the_text)
         match = re.match(self.re_trail, header_in)
         if match:
             pass
@@ -337,7 +339,7 @@ class ParseCRFile(object):
                 item['itemno'] = itemno
                 itemno += 1
                 the_content.append(item)
-            except Exception, e:
+            except Exception as e:
                 logging.warn('{0}'.format(e))
                 break
 
@@ -467,7 +469,7 @@ class ParseCRFile(object):
         # Must come after speaker list generation
         self.item_breakers = []
         self.skip_items = []
-        for x in self.item_types.values():
+        for x in list(self.item_types.values()):
             if x['break_flow'] == True:
                 self.item_breakers.extend(x['patterns'])
             else:

--- a/congressionalrecord/fdsys/downloader.py
+++ b/congressionalrecord/fdsys/downloader.py
@@ -1,4 +1,7 @@
+from __future__ import absolute_import
 #import requests
+from builtins import str
+from builtins import object
 import certifi
 import urllib3.contrib.pyopenssl
 urllib3.contrib.pyopenssl.inject_into_urllib3()
@@ -7,7 +10,7 @@ import os
 from datetime import datetime,date,timedelta
 from time import sleep
 from zipfile import ZipFile
-from cr_parser import ParseCRDir, ParseCRFile
+from .cr_parser import ParseCRDir, ParseCRFile
 import json
 from pyelasticsearch import ElasticSearch, bulk_chunks
 import logging
@@ -19,7 +22,7 @@ class Downloader(object):
     """
     def bulkdownload(self,start,parse=True,**kwargs):
         day = datetime.strptime(start,'%Y-%m-%d')
-        if 'end' in kwargs.keys():
+        if 'end' in list(kwargs.keys()):
             end = kwargs['end']
         else:
             end = start
@@ -33,7 +36,7 @@ class Downloader(object):
             elif parse:
                 dir_str = 'CREC-' + day_str
                 year_str = str(day.year)
-                if 'outpath' not in kwargs.keys():
+                if 'outpath' not in list(kwargs.keys()):
                     outpath = 'output'
                 else:
                     outpath = kwargs['outpath']
@@ -47,7 +50,7 @@ class Downloader(object):
                         else:
                             crfile = ParseCRFile(parse_path,crdir)
                             yield crfile
-                except IOError, e:
+                except IOError as e:
                     logging.warning('{0}, skipping.'.format(e))
             else:
                 logging.warning('Unexpected condition in bulkdownloader')
@@ -102,8 +105,8 @@ class Downloader(object):
         """
         self.status = 'idle'
         logging.debug('Downloader object ready with params:')
-        logging.debug(','.join(['='.join([key,value]) for key,value in kwargs.items()]))
-        if 'outpath' in kwargs.keys():
+        logging.debug(','.join(['='.join([key,value]) for key,value in list(kwargs.items())]))
+        if 'outpath' in list(kwargs.keys()):
             outpath = kwargs['outpath']
         else:
             outpath = 'output'
@@ -202,7 +205,7 @@ class fdsysDL(object):
 
     def __init__(self,day,**kwargs):
         self.status = 'idle'
-        if 'outpath' in kwargs.keys():
+        if 'outpath' in list(kwargs.keys()):
             self.outpath = kwargs['outpath']
         else:
             self.outpath = 'output'
@@ -215,7 +218,7 @@ class fdsysExtract(object):
         assert datetime.strptime(day,"%Y-%m-%d"), "Malformed date field. Must be 'YYYY-MM-DD'"
         dl_time = datetime.strptime(day,"%Y-%m-%d")
         year = str(dl_time.year)
-        if 'outpath' not in kwargs.keys():
+        if 'outpath' not in list(kwargs.keys()):
             outpath = 'output'
         else:
             outpath = kwargs['outpath']

--- a/congressionalrecord/fdsys/subclasses.py
+++ b/congressionalrecord/fdsys/subclasses.py
@@ -1,3 +1,4 @@
+from builtins import object
 import re
 import logging
 
@@ -21,7 +22,7 @@ class crItem(object):
         item_types = parent.item_types
         content = [parent.cur_line]
         # What is this line
-        for kind,params in item_types.items():
+        for kind,params in list(item_types.items()):
             for pat in params['patterns']:
                 amatch = re.match(pat,parent.cur_line)
                 if amatch:
@@ -33,7 +34,7 @@ class crItem(object):
                     if params['speaker_re']:
                         them = amatch.group(params['speaker_group'])
                         self.item['speaker'] = them
-                        if them in self.parent.speakers.keys():
+                        if them in list(self.parent.speakers.keys()):
                             self.item['speaker_bioguide'] = \
                               self.parent.speakers[them]['bioguideid']
                         else:

--- a/congressionalrecord/pg_config/populate_leg_tables.py
+++ b/congressionalrecord/pg_config/populate_leg_tables.py
@@ -46,19 +46,19 @@ def parse_legislators(afile,append=False,idstart=0):
                              ('votesmart','votesmart'),\
                              ('washington_post','washington_post'),\
                              ('wikipedia','wikipedia')]:
-             if inkey in leg['id'].keys():
+             if inkey in list(leg['id'].keys()):
                  bio_row[outkey] = leg['id'][inkey]
 
         for inkey,outkey in [('birthday','dob'),\
                              ('gender','gender'),\
                              ('religion','religion')]:
-            if inkey in leg['bio'].keys():
+            if inkey in list(leg['bio'].keys()):
                 bio_row[outkey] = leg['bio'][inkey]
 
         for inkey,outkey in [('first','name_first'),\
                              ('last','name_last'),\
                              ('official_full','official_full')]:
-            if inkey in leg['name'].keys():
+            if inkey in list(leg['name'].keys()):
                 bio_row[outkey] = leg['name'][inkey]
 
         bio_writer.writerow(bio_row)
@@ -78,11 +78,11 @@ def parse_legislators(afile,append=False,idstart=0):
                                  ('state','state'),\
                                  ('type','ttype'),\
                                  ('url','url')]:
-                if inkey in term.keys():
+                if inkey in list(term.keys()):
                     term_row[outkey] = term[inkey]
             term_writer.writerow(term_row)
 
-        if 'fec' not in leg['id'].keys():
+        if 'fec' not in list(leg['id'].keys()):
             pass
         else:
             for fec in leg['id']['fec']:

--- a/congressionalrecord/pg_run/pg_cr_bulkwrite.py
+++ b/congressionalrecord/pg_run/pg_cr_bulkwrite.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import psycopg2 as pc
 from psycopg2.extras import RealDictCursor as rdc
 from ..fdsys.downloader import Downloader as dl
@@ -7,7 +9,7 @@ import unicodecsv as csv
 import os
 
 def if_exists(key,store):
-    if key in store.keys():
+    if key in list(store.keys()):
         return store[key]
     else:
         logging.warning('{0} not in {1}, returning default value'.format(key,store))
@@ -64,7 +66,7 @@ class crToPG(object):
         pagestack.add(page_row)
 
         bills = []
-        if 'related_bills' in crfile.keys():
+        if 'related_bills' in list(crfile.keys()):
             for bill in crfile['related_bills']:
                 bill_row = OrderedDict([('congress',bill['congress']),
                             ('context',bill['context']),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-beautifulsoup4>=4.4.0
-lxml>=3.4.4
-numpy>=1.9.2
-psycopg2>=2.6.1
-pyelasticsearch>=1.4
-PyYAML>=3.11
-urllib3[secure]>1.15
-requests>=2.7.0
-SQLAlchemy>=1.0.8
-unicodecsv>=0.13.0
+-e .

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setup(
         'psycopg2 >= 2.6.1',
         'pyelasticsearch >= 1.4',
         'SQLAlchemy >= 1.0.8',
-        'requests >= 2.7.0',
+        'requests[security]',
         'PyYAML >= 3.11',
+        'future'
         ],
         zip_safe=False
     )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='congressionalrecord2',
+    name='congressionalrecord',
     version='0.9.1',
     description='Parse the U.S. Congressional Record from FDsys.',
-    url='https://github.com/nclarkjudd/congressionalrecord2',
+    url='https://github.com/unitedstates/congressional-record',
     author='Nick Judd',
     author_email='nick@nclarkjudd.com',
     license='BSD3',
@@ -18,6 +18,7 @@ setup(
         'SQLAlchemy >= 1.0.8',
         'requests[security]',
         'PyYAML >= 3.11',
+        'unicodecsv',
         'future'
         ],
         zip_safe=False

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -49,7 +49,7 @@ class testCRFile(unittest.TestCase):
 
     def test_content_length(self):
         crfile = cr.ParseCRFile(self.input_path,self.crdir)
-        self.assertGreater(crfile.crdoc['content'],0,msg='No items in content!')
+        self.assertGreater(len(crfile.crdoc['content']),0,msg='No items in content!')
 
 class testLineBreak(unittest.TestCase):
 


### PR DESCRIPTION
fixes #28 and #30, replaces #29 and #31 

- adds python 3 support via [future](http://python-future.org/): `futurize --both-stages --write --nobackups congressionalrecord`
- add PyOpenSSL via `requests[security]` to setup.py since there's an explicit dependency on PyOpenSSL in the code
- add `future` as a dependency in setup.py
- add `unicodecsv` as a dependency in setup.py
- fixes test_content_length test case
- change requirements.txt to rely on setup.py for dependencies since they were getting out of sync
- add python 35 and 36 to travis
- rename congressionalrecord2 to congressionalrecord
- change url from https://github.com/nclarkjudd/congressionalrecord2 to https://github.com/unitedstates/congressional-record
