### PR TITLE
Various style improvements

### DIFF
--- a/congressionalrecord/cli.py
+++ b/congressionalrecord/cli.py
@@ -27,7 +27,7 @@ def main():
     parser.add_argument(
         'do_mode',
         type=str,
-        choices=['json','es','pg','noparse'],
+        choices=['json', 'es', 'pg', 'noparse'],
         help='json: Store json\n \
         es: Push to ElasticSearch.\n \
         pg: Generate flatfiles for Postgres.\n \
@@ -57,16 +57,16 @@ def main():
 
 
     args = parser.parse_args()
-    logging.basicConfig(filename=args.logfile,level=logging.DEBUG)
+    logging.basicConfig(filename=args.logfile, level=logging.DEBUG)
     logging.info('Logging begins')
     if args.csvpath and args.do_mode == 'pg':
         cr(args.start, end=args.end, do_mode='yield', csvpath=args.csvpath)
     elif args.do_mode == 'pg':
-        cr(args.start,end=args.end,do_mode='yield')
+        cr(args.start, end=args.end, do_mode='yield')
     elif args.do_mode == 'json':
-        dl(args.start,end=args.end,do_mode='json')
+        dl(args.start, end=args.end, do_mode='json')
     elif args.do_mode == 'es':
-        dl(args.start,end=args.end,do_mode='es',es_url=args.es_url,index=args.index)
+        dl(args.start, end=args.end, do_mode='es', es_url=args.es_url, index=args.index)
     else:
         print("Haven't written the hooks for other functionality yet.")
 

--- a/congressionalrecord/govinfo/downloader.py
+++ b/congressionalrecord/govinfo/downloader.py
@@ -7,7 +7,7 @@ import urllib3.contrib.pyopenssl
 urllib3.contrib.pyopenssl.inject_into_urllib3()
 from urllib3 import PoolManager, Retry, Timeout
 import os
-from datetime import datetime,date,timedelta
+from datetime import datetime, date, timedelta
 from time import sleep
 from zipfile import ZipFile
 from .cr_parser import ParseCRDir, ParseCRFile
@@ -15,21 +15,22 @@ import json
 from pyelasticsearch import ElasticSearch, bulk_chunks
 import logging
 
+
 class Downloader(object):
     """
     Chunks through downloads and is ready to pass
     to elasticsearch or yield json.
     """
-    def bulkdownload(self,start,parse=True,**kwargs):
-        day = datetime.strptime(start,'%Y-%m-%d')
+    def bulkdownload(self, start, parse=True, **kwargs):
+        day = datetime.strptime(start, '%Y-%m-%d')
         if 'end' in list(kwargs.keys()):
             end = kwargs['end']
         else:
             end = start
-        end_day = datetime.strptime(end,'%Y-%m-%d')
+        end_day = datetime.strptime(end, '%Y-%m-%d')
         while day <= end_day:
-            day_str = datetime.strftime(day,'%Y-%m-%d')
-            extractor = GovInfoExtract(day_str,**kwargs)
+            day_str = datetime.strftime(day, '%Y-%m-%d')
+            extractor = GovInfoExtract(day_str, **kwargs)
             self.status = extractor.status
             if self.status == 404:
                 logging.info('bulkdownloader skipping a missing day.')
@@ -41,23 +42,25 @@ class Downloader(object):
                 else:
                     outpath = kwargs['outpath']
                 try:
-                    dir_path = os.path.join(outpath,year_str,dir_str)
+                    dir_path = os.path.join(outpath, year_str, dir_str)
                     crdir = ParseCRDir(dir_path)
-                    for the_file in os.listdir(os.path.join(dir_path,'html')):
-                        parse_path = os.path.join(dir_path,'html',the_file)
-                        if '-PgD' in parse_path or 'FrontMatter' in parse_path or '-Pgnull' in parse_path:
-                            logging.info('Skipping {0}'.format(parse_path))
+                    for the_file in os.listdir(os.path.join(dir_path, 'html')):
+                        parse_path = os.path.join(dir_path, 'html', the_file)
+                        if any(('-PgD' in parse_path,
+                                'FrontMatter' in parse_path,
+                                '-Pgnull' in parse_path)):
+                            logging.info('Skipping {}'.format(parse_path))
                         else:
-                            crfile = ParseCRFile(parse_path,crdir)
+                            crfile = ParseCRFile(parse_path, crdir)
                             yield crfile
                 except IOError as e:
-                    logging.warning('{0}, skipping.'.format(e))
+                    logging.warning('{}, skipping.'.format(e))
             else:
                 logging.warning('Unexpected condition in bulkdownloader')
             day += timedelta(days=1)
 
 
-    def __init__(self,start,**kwargs):
+    def __init__(self, start, **kwargs):
         """
         Invoke a Downloader object to get data from
         the Record. It will check to see if the necessary
@@ -105,33 +108,33 @@ class Downloader(object):
         """
         self.status = 'idle'
         logging.debug('Downloader object ready with params:')
-        logging.debug(','.join(['='.join([key,value]) for key,value in list(kwargs.items())]))
+        logging.debug(', '.join(['='.join([key, value]) for key, value in list(kwargs.items())]))
         if 'outpath' in list(kwargs.keys()):
             outpath = kwargs['outpath']
         else:
             outpath = 'output'
         if kwargs['do_mode'] == 'es':
             es = ElasticSearch(kwargs['es_url'])
-            for chunk in bulk_chunks((es.index_op(crfile.crdoc,id=crfile.crdoc.pop('id')) for crfile
-                                        in self.bulkdownload(start,**kwargs)),
+            for chunk in bulk_chunks((es.index_op(crfile.crdoc, id=crfile.crdoc.pop('id')) for crfile
+                                        in self.bulkdownload(start, **kwargs)),
                                         docs_per_chunk=100):
-                es.bulk(chunk,index=kwargs['index'],doc_type='crdoc')
+                es.bulk(chunk, index=kwargs['index'], doc_type='crdoc')
         elif kwargs['do_mode'] == 'json':
             # outpath called so often to make it easy to follow
             # the idea that we're traversing a directory tree
-            for crfile in self.bulkdownload(start,**kwargs):
+            for crfile in self.bulkdownload(start, **kwargs):
                 filename = os.path.split(crfile.filepath)[-1].split('.')[0] + '.json'
                 outpath = os.path.split(crfile.filepath)[0]
                 outpath = os.path.split(outpath)[0]
                 if 'json' not in os.listdir(outpath):
-                    os.mkdir(os.path.join(outpath,'json'))
-                outpath = os.path.join(outpath,'json',filename)
-                with open(outpath,'w') as out_json:
-                    json.dump(crfile.crdoc,out_json)
+                    os.mkdir(os.path.join(outpath, 'json'))
+                outpath = os.path.join(outpath, 'json', filename)
+                with open(outpath, 'w') as out_json:
+                    json.dump(crfile.crdoc, out_json)
         elif kwargs['do_mode'] == 'yield':
-            self.yielded = self.bulkdownload(start,parse=True,**kwargs)
+            self.yielded = self.bulkdownload(start, parse=True, **kwargs)
         elif kwargs['do_mode'] == 'noparse':
-            self.bulkdownload(start,parse=False,**kwargs)
+            self.bulkdownload(start, parse=False, **kwargs)
 
         else:
             return None
@@ -143,21 +146,21 @@ class Downloader(object):
 class downloadRequest(object):
 
     user_agent = {'user-agent': 'congressional-record 0.0.1 (https://github.com/unitedstates/congressional-record)'}
-    its_today = datetime.strftime(datetime.today(),'%Y-%m-%d %H:%M')
-    timeout = Timeout(connect=2.0,read=10.0)
-    retry = Retry(total=3,backoff_factor=300)
+    its_today = datetime.strftime(datetime.today(), '%Y-%m-%d %H:%M')
+    timeout = Timeout(connect=2.0, read=10.0)
+    retry = Retry(total=3, backoff_factor=300)
     retry.BACKOFF_MAX = 602
-    http = PoolManager(timeout=timeout,retries=retry,
+    http = PoolManager(timeout=timeout, retries=retry,
                        cert_reqs='CERT_REQUIRED',
                        ca_certs=certifi.where(),
                        headers=user_agent)
-    
-    def __init__(self,url,filename):
+
+    def __init__(self, url, filename):
         self.status = False
         try:
-            logging.info('Sending request on {0}'.format(self.its_today))
-            r = self.http.request('GET',url)
-            logging.debug('Request headers received with code {0}'.format(str(r.status)))
+            logging.info('Sending request on {}'.format(self.its_today))
+            r = self.http.request('GET', url)
+            logging.debug('Request headers received with code {}'.format(r.status))
             if r.status == 404:
                 logging.warn('Received 404, not retrying request.')
                 self.status = 404
@@ -167,56 +170,55 @@ class downloadRequest(object):
                 self.status = True
             else:
                 logging.warn('Unexpected condition, not continuing:\
-                {0}'.format(str(r.status)))
+                {}'.format(r.status))
         except urllib3.exceptions.MaxRetryError as ce:
             logging.warn('Error: %s - Aborting download' % ce)
         if self.status == False:
-            logging.warn('Failed to download file {0}'.format(url))
+            logging.warn('Failed to download file {}'.format(url))
         elif self.status == 404:
             logging.info('downloadRequester skipping file that returned 404.')
         elif self.binary_content:
-            with open(filename,'wb') as outfile:
+            with open(filename, 'wb') as outfile:
                 outfile.write(self.binary_content)
-            logging.info('Wrote {0}'.format(filename))
+            logging.info('Wrote {}'.format(filename))
         else:            
-            logging.info('No download for {0} and terminating with unexpected condition.\n'.format(url))
-            
+            logging.info('No download for {} and terminating with unexpected condition.\n'.format(url))
 
     
 class GovInfoDL(object):
     govinfo_cr_download_base = 'https://www.govinfo.gov/content/pkg/CREC-'
     
-    def download_day(self,day,outpath):
-        assert datetime.strptime(day,"%Y-%m-%d"), "Malformed date field. Must be 'YYYY-MM-DD'"
+    def download_day(self, day, outpath):
+        assert datetime.strptime(day, "%Y-%m-%d"), "Malformed date field. Must be 'YYYY-MM-DD'"
         the_url = self.govinfo_cr_download_base + day + '.zip'
-        dl_time = datetime.strptime(day,"%Y-%m-%d")
+        dl_time = datetime.strptime(day, "%Y-%m-%d")
         year = str(dl_time.year)
         if year not in os.listdir(outpath):
-            os.mkdir(os.path.join(outpath,year))
-        the_filename = os.path.join(outpath,year,'CREC-' + day + '.zip')
-        the_download = downloadRequest(the_url,the_filename)
+            os.mkdir(os.path.join(outpath, year))
+        the_filename = os.path.join(outpath, year, 'CREC-' + day + '.zip')
+        the_download = downloadRequest(the_url, the_filename)
         self.status = the_download.status
         if self.status == False:
-            logging.warn("fdsysDL received report that download for {0} did not complete.".format(day))
+            logging.warn("fdsysDL received report that download for {} did not complete.".format(day))
         elif self.status == 404:
-            logging.warning('fdsysDL received 404 report for {0}.'.format(day))
+            logging.warning('fdsysDL received 404 report for {}.'.format(day))
         else:
-            logging.info('fdsysDL received expected condition {0} for downloader'.format(the_download.status))
+            logging.info('fdsysDL received expected condition {} for downloader'.format(the_download.status))
 
-    def __init__(self,day,**kwargs):
+    def __init__(self, day, **kwargs):
         self.status = 'idle'
         if 'outpath' in list(kwargs.keys()):
             self.outpath = kwargs['outpath']
         else:
             self.outpath = 'output'
-        self.download_day(day,self.outpath)
+        self.download_day(day, self.outpath)
 
 class GovInfoExtract(object):
 
-    def __init__(self,day,**kwargs):
+    def __init__(self, day, **kwargs):
         self.status = 'idle'
-        assert datetime.strptime(day,"%Y-%m-%d"), "Malformed date field. Must be 'YYYY-MM-DD'"
-        dl_time = datetime.strptime(day,"%Y-%m-%d")
+        assert datetime.strptime(day, "%Y-%m-%d"), "Malformed date field. Must be 'YYYY-MM-DD'"
+        dl_time = datetime.strptime(day, "%Y-%m-%d")
         year = str(dl_time.year)
         if 'outpath' not in list(kwargs.keys()):
             outpath = 'output'
@@ -224,28 +226,30 @@ class GovInfoExtract(object):
             outpath = kwargs['outpath']
         if not os.path.isdir(outpath):
             os.makedirs(outpath)
-        abspath = os.path.join(outpath,year,'CREC-' + day + '.zip')
+        abspath = os.path.join(outpath, year, 'CREC-' + day + '.zip')
         extract_to = 'CREC-' + day
         if year not in os.listdir(outpath):
-            os.mkdir(os.path.join(outpath,year))
-        if extract_to in os.listdir(os.path.join(outpath,year)):
-            logging.info("{0} already exists in extraction tree.".format(extract_to))
+            os.mkdir(os.path.join(outpath, year))
+        if extract_to in os.listdir(os.path.join(outpath, year)):
+            logging.info("{} already exists in extraction tree.".format(
+                extract_to))
             self.status = 'existingFiles'
             return None
-        if extract_to + '.zip' not in os.listdir(os.path.join(outpath,year)):
-            the_dl = GovInfoDL(day,outpath=outpath)
+        if extract_to + '.zip' not in os.listdir(os.path.join(outpath, year)):
+            the_dl = GovInfoDL(day, outpath=outpath)
             self.status = the_dl.status
-            if self.status != True:
+            if self.status is not True:
                 logging.info('No record on this day, not trying to extract')
                 self.status = 'downloadFailure'
                 return None
-        with ZipFile(abspath,'r') as the_zip:
-            the_zip.extractall(os.path.join(outpath,year))
-            logging.info('Extracted to {0}'.format(os.path.join(outpath,year)))
+        with ZipFile(abspath, 'r') as the_zip: # errors here
+            the_zip.extractall(os.path.join(outpath, year))
+            logging.info('Extracted to {}'.format(os.path.join(outpath,
+                                                                year)))
             self.status = 'extractedFiles'
         os.remove(abspath)
         self.status += 'deletedZip'
-        logging.info('Extractor completed with status {0}'.format(self.status))
+        logging.info('Extractor completed with status {}'.format(self.status))
 
 
 


### PR DESCRIPTION
Hello, I wrote a few minor cosmetic changes to the scripts here while trying to get a command working and would like to suggest their adoption.

* Follow commas with spaces
* Remove the redundant `str(...)` call in instances of `format(str(...))`
* Fix too-long lines
* Removed redundant numbers in `'string: {0}'.format(...)` calls